### PR TITLE
Add JWT login and student QR flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,34 @@
 
 A new Flutter project.
 
-## Getting Started
+## Backend
 
-This project is a starting point for a Flutter application.
+The Node API now exposes authentication with JWT. Before running, configure:
+
+```bash
+export JWT_SECRET=supersecret
+export ALLOWED_EMAIL_DOMAINS=example.edu
+```
+
+Then start the API from `api_carnet/`:
+
+```bash
+node index.js
+```
+
+### Sample users
+
+The demo comes with a student (`alumno1@example.edu` / `password123`) and a
+teacher (`docente@example.edu` / `password123`). The student code is used as the
+main identifier across the system.
+
+## Frontend
+
+Run `flutter pub get` and then start the app on an emulator or device. The app
+first shows a login screen and stores the received token to call protected
+endpoints.
+
+## Getting Started with Flutter
 
 A few resources to get you started if this is your first Flutter project:
 

--- a/api_carnet/package-lock.json
+++ b/api_carnet/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "bcryptjs": "^3.0.2",
         "cors": "^2.8.5",
         "express": "^5.1.0",
         "helmet": "^8.1.0",
@@ -34,6 +35,15 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/bcryptjs": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-3.0.2.tgz",
+      "integrity": "sha512-k38b3XOZKv60C4E2hVsXTolJWfkGRMbILBIe2IBITXciy5bOsTKot5kDrf3ZfufQtQOUN5mXceUEpU1rTl9Uog==",
+      "license": "BSD-3-Clause",
+      "bin": {
+        "bcrypt": "bin/bcrypt"
       }
     },
     "node_modules/body-parser": {

--- a/api_carnet/package.json
+++ b/api_carnet/package.json
@@ -11,6 +11,7 @@
   "license": "ISC",
   "description": "",
   "dependencies": {
+    "bcryptjs": "^3.0.2",
     "cors": "^2.8.5",
     "express": "^5.1.0",
     "helmet": "^8.1.0",

--- a/api_carnet/users.js
+++ b/api_carnet/users.js
@@ -1,0 +1,16 @@
+export const users = [
+  {
+    code: "U20230001",
+    email: "alumno1@example.edu",
+    name: "Alumno Uno",
+    role: "student",
+    passwordHash: "$2b$10$kex/FEd9ELMutckwBETx2u2E52FdIKsE8YGvXSw02k6BVZpEvGatS"
+  },
+  {
+    code: "DOC123",
+    email: "docente@example.edu",
+    name: "Docente Uno",
+    role: "teacher",
+    passwordHash: "$2b$10$kex/FEd9ELMutckwBETx2u2E52FdIKsE8YGvXSw02k6BVZpEvGatS"
+  }
+];

--- a/lib/login_page.dart
+++ b/lib/login_page.dart
@@ -1,0 +1,104 @@
+import 'dart:convert';
+import 'package:flutter/material.dart';
+import 'package:http/http.dart' as http;
+import 'package:shared_preferences/shared_preferences.dart';
+
+class LoginPage extends StatefulWidget {
+  const LoginPage({super.key});
+
+  @override
+  State<LoginPage> createState() => _LoginPageState();
+}
+
+class _LoginPageState extends State<LoginPage> {
+  final _emailController = TextEditingController();
+  final _passController = TextEditingController();
+  bool _loading = false;
+  String? _error;
+  final String _baseUrl = "http://10.0.2.2:3000";
+
+  @override
+  void initState() {
+    super.initState();
+    _checkToken();
+  }
+
+  Future<void> _checkToken() async {
+    final prefs = await SharedPreferences.getInstance();
+    if (prefs.getString('token') != null) {
+      if (!mounted) return;
+      Navigator.of(context).pushReplacementNamed('/carnet');
+    }
+  }
+
+  Future<void> _login() async {
+    setState(() {
+      _loading = true;
+      _error = null;
+    });
+    try {
+      final resp = await http.post(
+        Uri.parse("$_baseUrl/auth/login"),
+        headers: {"Content-Type": "application/json"},
+        body: jsonEncode({
+          "email": _emailController.text,
+          "password": _passController.text,
+        }),
+      );
+      if (resp.statusCode == 200) {
+        final data = jsonDecode(resp.body) as Map<String, dynamic>;
+        final prefs = await SharedPreferences.getInstance();
+        await prefs.setString('token', data['token'] as String);
+        if (!mounted) return;
+        Navigator.of(context).pushReplacementNamed('/carnet');
+      } else {
+        setState(() {
+          _error = 'Credenciales inválidas';
+        });
+      }
+    } catch (e) {
+      setState(() {
+        _error = 'Error de red';
+      });
+    } finally {
+      if (mounted) {
+        setState(() {
+          _loading = false;
+        });
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Login')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          children: [
+            TextField(
+              controller: _emailController,
+              decoration: const InputDecoration(labelText: 'Email'),
+            ),
+            TextField(
+              controller: _passController,
+              decoration: const InputDecoration(labelText: 'Password'),
+              obscureText: true,
+            ),
+            const SizedBox(height: 16),
+            if (_error != null)
+              Text(_error!, style: const TextStyle(color: Colors.red)),
+            const SizedBox(height: 16),
+            ElevatedButton(
+              onPressed: _loading ? null : _login,
+              child: _loading
+                  ? const CircularProgressIndicator()
+                  : const Text('Ingresar'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -36,6 +36,7 @@ dependencies:
   cupertino_icons: ^1.0.8
   qr_flutter: ^4.1.0
   http: ^1.5.0
+  shared_preferences: ^2.2.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- replace fake student middleware with real JWT auth and domain check
- issue ephemeral QR tokens using authenticated student code
- add Flutter login screen storing token and calling protected endpoint

## Testing
- `npm test` (fails: Error: no test specified)
- `flutter pub get` (fails: command not found)


------
https://chatgpt.com/codex/tasks/task_b_68b098fc75e08327b5149703fd231fe6