### PR TITLE
Add registration screen with photo picker

### DIFF
--- a/lib/login_page.dart
+++ b/lib/login_page.dart
@@ -152,6 +152,10 @@ class _LoginPageState extends State<LoginPage> {
                     : const Text('Ingresar'),
               ),
             ),
+            TextButton(
+              onPressed: () => Navigator.of(context).pushNamed('/register'),
+              child: const Text('Crear cuenta'),
+            ),
           ],
         ),
       ),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -11,6 +11,7 @@ import 'student_checkin_scanner.dart';
 import 'porter_page.dart';
 import 'app_theme.dart';
 import 'api_config.dart';
+import 'register_page.dart';
 
 void main() {
   runApp(ThemeController(child: const App()));
@@ -33,6 +34,7 @@ class App extends StatelessWidget {
         '/teacher': (_) => const TeacherPage(),
         '/porter': (_) => const PorterPage(),
         '/scan-checkin': (_) => const StudentCheckInScanner(),
+        '/register': (_) => const RegisterPage(),
       },
       home: const LoginPage(),
     );

--- a/lib/register_page.dart
+++ b/lib/register_page.dart
@@ -1,0 +1,126 @@
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart';
+import 'package:image_picker/image_picker.dart';
+import 'package:flutter/foundation.dart' show kIsWeb;
+
+import 'app_theme.dart';
+
+class RegisterPage extends StatefulWidget {
+  const RegisterPage({super.key});
+
+  @override
+  State<RegisterPage> createState() => _RegisterPageState();
+}
+
+class _RegisterPageState extends State<RegisterPage> {
+  final _nameController = TextEditingController();
+  final _emailController = TextEditingController();
+  final _passwordController = TextEditingController();
+  final _programController = TextEditingController();
+  DateTime? _expiryDate;
+  Uint8List? _photoBytes;
+
+  final ImagePicker _picker = ImagePicker();
+
+  Future<void> _pickExpiryDate() async {
+    final now = DateTime.now();
+    final picked = await showDatePicker(
+      context: context,
+      initialDate: now,
+      firstDate: now,
+      lastDate: DateTime(now.year + 5),
+    );
+    if (picked != null) {
+      setState(() => _expiryDate = picked);
+    }
+  }
+
+  Future<void> _pickPhoto() async {
+    final file = await _picker.pickImage(source: ImageSource.gallery);
+    if (file != null) {
+      final bytes = await file.readAsBytes();
+      setState(() => _photoBytes = bytes);
+    }
+  }
+
+  void _submit() {
+    // TODO: connect with backend
+    ScaffoldMessenger.of(context)
+        .showSnackBar(const SnackBar(content: Text('Registro no implementado')));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar:
+          AppBar(title: const Text('Registro'), actions: const [ThemeToggleButton()]),
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            TextField(
+              controller: _nameController,
+              decoration: const InputDecoration(labelText: 'Nombre'),
+            ),
+            const SizedBox(height: 15),
+            TextField(
+              controller: _emailController,
+              decoration: const InputDecoration(labelText: 'Correo'),
+            ),
+            const SizedBox(height: 15),
+            TextField(
+              controller: _passwordController,
+              decoration: const InputDecoration(labelText: 'Contraseña'),
+              obscureText: true,
+            ),
+            const SizedBox(height: 15),
+            TextField(
+              controller: _programController,
+              decoration: const InputDecoration(labelText: 'Programa'),
+            ),
+            const SizedBox(height: 15),
+            GestureDetector(
+              onTap: _pickExpiryDate,
+              child: AbsorbPointer(
+                child: TextField(
+                  decoration: InputDecoration(
+                    labelText: 'Fecha de vencimiento',
+                    hintText: _expiryDate == null
+                        ? 'Opcional'
+                        : '${_expiryDate!.day}/${_expiryDate!.month}/${_expiryDate!.year}',
+                  ),
+                ),
+              ),
+            ),
+            const SizedBox(height: 15),
+            Center(
+              child: GestureDetector(
+                onTap: _pickPhoto,
+                child: Container(
+                  width: 150,
+                  height: 150,
+                  decoration: BoxDecoration(
+                    border: Border.all(color: Colors.grey),
+                    borderRadius: BorderRadius.circular(8),
+                    color: Colors.grey.shade200,
+                  ),
+                  child: _photoBytes == null
+                      ? const Icon(Icons.photo_camera, size: 60)
+                      : Image.memory(_photoBytes!, fit: BoxFit.cover),
+                ),
+              ),
+            ),
+            const SizedBox(height: 24),
+            ElevatedButton(
+              onPressed: _submit,
+              child: const Text('Registrar'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -38,6 +38,7 @@ dependencies:
   http: ^1.5.0
   shared_preferences: ^2.2.2
   mobile_scanner: ^3.5.5
+  image_picker: ^1.0.7
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- create registration form allowing name, email, password, program, optional expiry date, and photo selection
- link registration screen from login page and register route
- add image_picker dependency for photo capture

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_b_68c37936c4a88321b9602025a2abd8e5