### PR TITLE
feat: enhance student registration workflow with carnet data

### DIFF
--- a/api_carnet/index.js
+++ b/api_carnet/index.js
@@ -73,8 +73,40 @@ app.post("/auth/login", async (req, res) => {
       email: user.email,
       role: user.role,
       name: user.name,
+      program: user.program,
+      expiresAt: user.expiresAt,
     },
   });
+});
+
+// Registro de nuevos estudiantes
+app.post("/auth/register", async (req, res) => {
+  try {
+    const { code, email, name, password, program, expiresAt, role, photo } = req.body || {};
+    if (!code || !email || !name || !password) {
+      return res.status(400).json({ error: "missing_fields" });
+    }
+    const exists = users.some((u) => u.email === email || u.code === code);
+    if (exists) {
+      return res.status(409).json({ error: "user_exists" });
+    }
+    const passwordHash = await bcrypt.hash(password, 10);
+    const newUser = {
+      code,
+      email,
+      name,
+      role: role || "student",
+      program,
+      expiresAt,
+      photoUrl: photo || null,
+      passwordHash,
+    };
+    users.push(newUser);
+    const ephemeralCode = uuidv4();
+    res.json({ success: true, ephemeralCode });
+  } catch (e) {
+    res.status(500).json({ error: "registration_failed" });
+  }
 });
 
 function requireAuth(role) {
@@ -124,7 +156,8 @@ app.post("/issue-ephemeral", requireAuth("student"), async (req, res) => {
     setTimeout(() => usedJti.delete(jti), TOKEN_TTL_SECONDS * 1000 + 2000);
 
     const qrUrl = `http://localhost:${PORT}/verify?t=${encodeURIComponent(token)}`;
-    const student = users.find((u) => u.code === code);
+    const found = users.find((u) => u.code === code);
+    const { passwordHash: _ph, ...student } = found || {};
 
     res.json({ token, qrUrl, ttl: TOKEN_TTL_SECONDS, student });
   } catch (e) {

--- a/api_carnet/users.js
+++ b/api_carnet/users.js
@@ -4,6 +4,9 @@ export const users = [
     email: "alumno1@example.edu",
     name: "Alumno Uno",
     role: "student",
+    program: "INGENIERIA DE SISTEMAS",
+    expiresAt: "30/06/2025",
+    photoUrl: null,
     passwordHash: "$2b$10$kex/FEd9ELMutckwBETx2u2E52FdIKsE8YGvXSw02k6BVZpEvGatS"
   },
   {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -250,7 +250,7 @@ class _CarnetPageState extends State<CarnetPage> {
                     children: [
                       Expanded(
                         child: Text(
-                          s?["id"] ?? "430075236",
+                          s?["code"] ?? s?["id"] ?? "430075236",
                           style: const TextStyle(
                             color: grisTexto,
                             fontSize: 18,
@@ -259,10 +259,10 @@ class _CarnetPageState extends State<CarnetPage> {
                         ),
                       ),
                       const SizedBox(width: 6),
-                      const Expanded(
+                      Expanded(
                         child: Text(
-                          "30/06/2025",
-                          style: TextStyle(
+                          s?["expiresAt"] ?? "30/06/2025",
+                          style: const TextStyle(
                             color: grisTexto,
                             fontSize: 18,
                             fontWeight: FontWeight.w800,
@@ -407,9 +407,17 @@ class _FotoBox extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final img = (photoUrl != null && photoUrl!.isNotEmpty)
-        ? Image.network(photoUrl!, fit: BoxFit.cover)
-        : Image.asset(photoAssetPath, fit: BoxFit.cover);
+    Image img;
+    if (photoUrl != null && photoUrl!.isNotEmpty) {
+      if (photoUrl!.startsWith('data:image')) {
+        final b64 = photoUrl!.split(',').last;
+        img = Image.memory(base64Decode(b64), fit: BoxFit.cover);
+      } else {
+        img = Image.network(photoUrl!, fit: BoxFit.cover);
+      }
+    } else {
+      img = Image.asset(photoAssetPath, fit: BoxFit.cover);
+    }
 
     return Container(
       width: width,

--- a/lib/register_page.dart
+++ b/lib/register_page.dart
@@ -1,10 +1,12 @@
 import 'dart:typed_data';
+import 'dart:convert';
 
 import 'package:flutter/material.dart';
 import 'package:image_picker/image_picker.dart';
-import 'package:flutter/foundation.dart' show kIsWeb;
+import 'package:http/http.dart' as http;
 
 import 'app_theme.dart';
+import 'api_config.dart';
 
 class RegisterPage extends StatefulWidget {
   const RegisterPage({super.key});
@@ -15,9 +17,11 @@ class RegisterPage extends StatefulWidget {
 
 class _RegisterPageState extends State<RegisterPage> {
   final _nameController = TextEditingController();
+  final _codeController = TextEditingController();
   final _emailController = TextEditingController();
   final _passwordController = TextEditingController();
   final _programController = TextEditingController();
+  final _roleController = TextEditingController(text: 'student');
   DateTime? _expiryDate;
   Uint8List? _photoBytes;
 
@@ -45,9 +49,62 @@ class _RegisterPageState extends State<RegisterPage> {
   }
 
   void _submit() {
-    // TODO: connect with backend
-    ScaffoldMessenger.of(context)
-        .showSnackBar(const SnackBar(content: Text('Registro no implementado')));
+    final expiry = _expiryDate != null
+        ? '${_expiryDate!.day.toString().padLeft(2, '0')}/${_expiryDate!.month.toString().padLeft(2, '0')}/${_expiryDate!.year}'
+        : null;
+    showDialog(
+      context: context,
+      barrierDismissible: false,
+      builder: (_) => const Center(child: CircularProgressIndicator()),
+    );
+    http
+        .post(
+      Uri.parse('${ApiConfig.baseUrl}/auth/register'),
+      headers: {'Content-Type': 'application/json'},
+      body: jsonEncode({
+        'code': _codeController.text,
+        'email': _emailController.text,
+        'name': _nameController.text,
+        'password': _passwordController.text,
+        'program': _programController.text,
+        'expiresAt': expiry,
+        'role': _roleController.text,
+        'photo': _photoBytes != null ? 'data:image/png;base64,' + base64Encode(_photoBytes!) : null,
+      }),
+    )
+        .then((resp) {
+      Navigator.of(context).pop();
+      if (resp.statusCode == 200) {
+        final data = jsonDecode(resp.body) as Map<String, dynamic>;
+        showDialog(
+          context: context,
+          builder: (_) => AlertDialog(
+            title: const Text('Registro exitoso'),
+            content: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                if (_photoBytes != null)
+                  Image.memory(_photoBytes!, width: 120, height: 120, fit: BoxFit.cover),
+                const SizedBox(height: 12),
+                Text('Código efímero: ${data['ephemeralCode']}'),
+              ],
+            ),
+          ),
+        );
+        Future.delayed(const Duration(seconds: 2), () {
+          Navigator.of(context)
+              .pushNamedAndRemoveUntil('/login', (route) => false);
+        });
+      } else {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Error al registrar')),
+        );
+      }
+    }).catchError((_) {
+      Navigator.of(context).pop();
+      ScaffoldMessenger.of(context)
+          .showSnackBar(const SnackBar(content: Text('Error de red')));
+    });
   }
 
   @override
@@ -60,6 +117,11 @@ class _RegisterPageState extends State<RegisterPage> {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
+            TextField(
+              controller: _codeController,
+              decoration: const InputDecoration(labelText: 'Código'),
+            ),
+            const SizedBox(height: 15),
             TextField(
               controller: _nameController,
               decoration: const InputDecoration(labelText: 'Nombre'),
@@ -79,6 +141,12 @@ class _RegisterPageState extends State<RegisterPage> {
             TextField(
               controller: _programController,
               decoration: const InputDecoration(labelText: 'Programa'),
+            ),
+            const SizedBox(height: 15),
+            TextField(
+              controller: _roleController,
+              decoration: const InputDecoration(labelText: 'Rol'),
+              readOnly: true,
             ),
             const SizedBox(height: 15),
             GestureDetector(


### PR DESCRIPTION
## Summary
- capture full student card info during registration and send it to backend
- add API endpoint for registering students and expose program/expiry data
- show carnet with code, expiry date and base64 photo; sanitize QR responses

## Testing
- `dart analyze` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_b_68c43e1363f08321acba1f40294d6fc5